### PR TITLE
feat: added displayData.json file for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ This is a webpack project configured to build Platform.Bible extensions. The gen
       - `*.web-view.tsx` files will be treated as React WebViews
       - `*.web-view.html` files are a conventional way to provide HTML WebViews (no special functionality)
     - `assets/` contains asset files the extension and its WebViews can retrieve using the `papi-extension:` protocol. It is copied into the build folder
-    - `contributions/` contains JSON files the platform uses to extend data structures for things like menus and settings. The JSON files are referenced from the manifest
+    - `contributions/` contains JSON files the platform uses to extend data structures for things like menus, settings, and descriptions. The JSON files are referenced from the manifest
+      - `contributions/displayData.json` contains (optionally) a path to the extension's icon file as well as text for the extension's display name, short summary, and path to the full description file
+      - `contributions/description-<locale>.md` contains a brief description of the extension in the language specified by `<locale>`
     - `public/` contains other static files that are copied into the build folder
 - `dist/` is a generated folder containing the built extension files
 - `release/` is a generated folder containing zips of the built extension files

--- a/webpack/webpack.util.ts
+++ b/webpack/webpack.util.ts
@@ -133,6 +133,8 @@ const staticFiles: {
   { from: '<project_settings>', noErrorOnMissing: true },
   // Copy the localized strings JSON file into the output folder based on its listing in `manifest.localizedStrings`
   { from: '<localized_strings>', noErrorOnMissing: true },
+  // Copy the display data JSON file into the output folder based on its listing in `manifest.localizedStrings`
+  { from: '<display_data>', noErrorOnMissing: true },
 ];
 
 /** Get the actual static file name from the template static file name */
@@ -143,7 +145,8 @@ function getStaticFileName(staticFile: string, extensionInfo: ExtensionInfo) {
     .replace(/<menus>/g, extensionInfo.menus ?? '')
     .replace(/<settings>/g, extensionInfo.settings ?? '')
     .replace(/<project_settings>/g, extensionInfo.projectSettings ?? '')
-    .replace(/<localized_strings>/g, extensionInfo.localizedStrings ?? '');
+    .replace(/<localized_strings>/g, extensionInfo.localizedStrings ?? '')
+    .replace(/<display_data>/g, extensionInfo.displayData ?? '');
 }
 
 /** Get CopyFile plugin patterns for copying static files for an extension */
@@ -291,6 +294,8 @@ type ExtensionManifest = {
   projectSettings?: string;
   /** Path to the JSON file that defines the localized strings this extension is adding. */
   localizedStrings?: string;
+  /** Path to the JSON file that defines the localized display data this extension is adding. */
+  displayData?: string;
   activationEvents: string[];
 };
 


### PR DESCRIPTION
Extends [this](https://github.com/paranext/paranext-extension-template/pull/70) change in `paranext-extension-template`.

I believe I've made the necessary changes, based off of [this commit](https://github.com/paranext/paranext-multi-extension-template/commit/e74c55c95f6d8b633ce7982c6409ee266a4cf7fb) TJ referred me to.

If I've missed something, please let me know.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/20)
<!-- Reviewable:end -->
