### PR TITLE
refactor: adjusted file structure for extension descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ This is a webpack project configured to build Platform.Bible extensions. The gen
       - `src/types/<extension_name>.d.ts` is this extension's types file that defines how other extensions can use this extension through the `papi`
       - `*.web-view.tsx` files will be treated as React WebViews
       - `*.web-view.html` files are a conventional way to provide HTML WebViews (no special functionality)
-    - `assets/` contains asset files the extension and its WebViews can retrieve using the `papi-extension:` protocol. It is copied into the build folder
-    - `contributions/` contains JSON files the platform uses to extend data structures for things like menus, settings, and descriptions. The JSON files are referenced from the manifest
-      - `contributions/displayData.json` contains (optionally) a path to the extension's icon file as well as text for the extension's display name, short summary, and path to the full description file
-      - `contributions/description-<locale>.md` contains a brief description of the extension in the language specified by `<locale>`
+    - `assets/` contains asset files the extension and its WebViews can retrieve using the `papi-extension:` protocol, as well as textual descriptions in various languages. It is copied into the build folder
+      - `assets/displayData.json` contains (optionally) a path to the extension's icon file as well as text for the extension's display name, short summary, and path to the full description file
+      - `assets/descriptions/` contains textual descriptions of the extension in various languages
+        - `assets/descriptions/description-<locale>.md` contains a brief description of the extension in the language specified by `<locale>`
+    - `contributions/` contains JSON files the platform uses to extend data structures for things like menus and settings. The JSON files are referenced from the manifest
     - `public/` contains other static files that are copied into the build folder
 - `dist/` is a generated folder containing the built extension files
 - `release/` is a generated folder containing zips of the built extension files


### PR DESCRIPTION
Addresses [this](https://discord.com/channels/1064938364597436416/1247202026966876215/1257461882697158687) message from TJ regarding the file structure of `displayData` and `descriptions`.

Message text:
> Hey everyone! Let's make another update to `displayData.json` sometime:
> 
> Let's put `displayData.json` and all the `description-<locale>.md` files in `assets` instead of in `contributions`. `contributions` is more along the lines of files that affect how Platform.Bible runs, while `assets` is more about data files of various sorts. Additionally, let's group these files in some more organized way so they don't end up drowning the other files with hundreds of locale files. There's freedom to choose how exactly you want to implement, but here's an example so you have an idea of what I'm suggesting:
> 
> ```
> - assets
>   - displayData.json
>   - descriptions
>     - description-en.md
>     - description-es.md
> ```
> 
> Thanks! As always, keep up the great work 🙂