### PR TITLE
Ignore node modules in tailwind config

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,7 @@ import typography from '@tailwindcss/typography';
 import tailwindCssAnimate from 'tailwindcss-animate';
 
 const config: Config = {
-  content: ['./src/**/*.{js,ts,jsx,tsx}', '!./src/**/node_modules/**/*'],
+  content: ['./src/**/*.{js,ts,jsx,tsx}', '!./**/node_modules/**/*'],
   // Prefix on all tailwind classes so they don't clash with built-in classes
   // short for tailwind - we hope to have the same prefix as users of this library so the cn
   // function that uses tailwind-merge can properly overwrite related tailwind classes


### PR DESCRIPTION
Seeing this warning, ignoring extension node modules in tailwind config to remove it. Will update from templates once this is merged.

```
warn - Your `content` configuration includes a pattern which looks like it's accidentally matching all of `node_modules` and can cause serious performance issues.
warn - Pattern: `./src/**/*.js`
warn - See our documentation for recommendations:
warn - https://tailwindcss.com/docs/content-configuration#pattern-recommendations
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/33)
<!-- Reviewable:end -->
