### PR TITLE
Added link where it was missing, changed license to use copyright symbol

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <year> <copyright_holder_name>
+Copyright © <year> <copyright_holder_name>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Template for creating multiple Platform.Bible extensions in one repo
 
 ## Template Info
 
-This is a webpack project template pre-configured to build an arbitrary number of Platform.Bible extensions. It contains the bare minimum of what a multi-extension repo needs. Note that many of the files mentioned in [Summary](#summary) are not present in this template because they describe extension code which must be added to this template. For inspiration on what extensions in a multi-extension repo could look like, refer to any repo forked from this template. An example would be the [paranext-sample-extensions]() [MISSING! PLEASE ADD WHEN AVAILABLE].
+This is a webpack project template pre-configured to build an arbitrary number of Platform.Bible extensions. It contains the bare minimum of what a multi-extension repo needs. Note that many of the files mentioned in [Summary](#summary) are not present in this template because they describe extension code which must be added to this template. For inspiration on what extensions in a multi-extension repo could look like, refer to any repo forked from this template. An example would be the [platform-bible-sample-extensions](https://github.com/paranext/platform-bible-sample-extensions).
 
 ### Customize repo details
 


### PR DESCRIPTION
Small fixes I noticed while working on https://github.com/sillsdev/scripture-forge-platform-extensions/pull/1

Updated copyright symbol because Tom did it on the single template.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/35)
<!-- Reviewable:end -->
