### PR TITLE
Update .eslintrc.cjs from the extension-template repo

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,6 +26,8 @@ module.exports = {
     // A temporary hack related to IDE not resolving correct package.json
     'import/no-extraneous-dependencies': 'off',
     'import/no-import-module-exports': 'off',
+    'import/no-unresolved': 'error',
+    'import/prefer-default-export': 'off',
     'react/jsx-filename-extension': 'off',
     'react/react-in-jsx-scope': 'off',
 
@@ -126,13 +128,6 @@ module.exports = {
       files: ['*.js'],
       rules: {
         strict: 'off',
-      },
-    },
-    {
-      // Don't require extensions to have a default export for "activate()"
-      files: ['*.ts'],
-      rules: {
-        'import/prefer-default-export': 'off',
       },
     },
     {


### PR DESCRIPTION
`prefer-default-export` is in the process of being disabled in paranext-core
`no-unresolved` has been in paranext-core since the beginning but was dropped here in the template for some reason