### PR TITLE
PT-3107: Improve release workflow

### DIFF
--- a/.github/actions/bump-versions-action/action.yml
+++ b/.github/actions/bump-versions-action/action.yml
@@ -1,0 +1,19 @@
+name: Bump Versions Action
+description: |
+  Runs bump-versions.ts script
+
+inputs:
+  newVersion:
+    description: "Version to bump all the repo's versions to on a new branch (called `bump-versions-<version>`), e.g. 0.3.0-alpha.0."
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Bump repo versions
+      # Bump versions using the built-in git token https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#push-a-commit-using-the-built-in-token
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        npm run bump-versions -- ${{ inputs.newVersion }}

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -1,0 +1,51 @@
+name: Bump Versions
+run-name: Bump versions on ${{ github.head_ref || github.ref_name }} to ${{ github.event.inputs.newVersion }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      newVersion:
+        description: "Version to bump all the repo's versions to on a new branch (called `bump-versions-<version>`), e.g. 0.3.0-alpha.0."
+        required: true
+
+jobs:
+  bump-versions:
+    name: Bump versions on ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Output Workflow Dispatch Inputs
+        run: echo "${{ toJSON(github.event.inputs) }}"
+
+      - name: Checkout git repo
+        uses: actions/checkout@v4
+
+      - name: Read package.json
+        id: package_json
+        uses: zoexx/github-action-json-file-properties@1.0.6
+        with:
+          file_path: 'package.json'
+
+      - name: Install Node and NPM
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
+
+      - name: Install packages
+        run: |
+          npm ci
+
+      - name: Bump repo versions
+        if: ${{ inputs.newVersion != '' }}
+        uses: ./.github/actions/bump-versions-action
+        with:
+          newVersion: ${{ inputs.newVersion }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,10 @@ jobs:
           omitPrereleaseDuringUpdate: true
           # make the new release a pre-release
           prerelease: true
+          # tag+commit creates a version tag for this release with the tag name at the commit ref
+          # so the GitHub Release doesn't have to create the tag and assume it is on `main`
           tag: v${{ inputs.version }}
+          commit: ${{ github.head_ref || github.ref_name }}
           # only update if the release is still a draft
           updateOnlyUnreleased: true
 
@@ -116,11 +119,9 @@ jobs:
 
       - name: Bump repo versions
         if: ${{ inputs.newVersionAfterPublishing != '' }}
-        # Bump versions using the built-in git token https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#push-a-commit-using-the-built-in-token
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          npm run bump-versions -- ${{ inputs.newVersionAfterPublishing }}
+        uses: ./.github/actions/bump-versions-action
+        with:
+          newVersion: ${{ inputs.newVersionAfterPublishing }}
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/lib/bump-versions.ts
+++ b/lib/bump-versions.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { getExtensions } from '../webpack/webpack.util';
 import { checkForWorkingChanges, execCommand } from './git.util';
 
-// #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext/blob/main/lib/bump-versions.ts
+// #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts
 
 // This script checks out a new branch, bumps the versions of all extensions in the repo,
 // and then commits the changes. It is generally expected that you will be on `main` when you run
@@ -16,9 +16,13 @@ import { checkForWorkingChanges, execCommand } from './git.util';
 const newVersion = process.argv[2];
 const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes');
 
+// #endregion
+
+// #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext/blob/main/lib/bump-versions.ts
+
 (async () => {
   // Make sure there are not working changes so we don't interfere with normal edits
-  if (!shouldAllowWorkingChanges && (await checkForWorkingChanges())) return 1;
+  if (!shouldAllowWorkingChanges && (await checkForWorkingChanges())) process.exit(1);
 
   const branchName = `bump-versions-${newVersion}`;
 
@@ -27,7 +31,7 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
     await execCommand(`git checkout -b ${branchName}`);
   } catch (e) {
     console.error(`Error on git checkout: ${e}`);
-    return 1;
+    process.exit(1);
   }
 
   const bumpVersionCommand = `npm version ${newVersion} --git-tag-version false`;
@@ -37,7 +41,7 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
     await execCommand(bumpVersionCommand);
   } catch (e) {
     console.error(`Error on bumping version: ${e}`);
-    return 1;
+    process.exit(1);
   }
 
   // #endregion
@@ -68,7 +72,7 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
         });
       } catch (e) {
         console.error(`Error on bumping package version for extension ${ext.name}: ${e}`);
-        return 1;
+        process.exit(1);
       }
     }
 
@@ -83,32 +87,40 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
       );
     } catch (e) {
       console.error(`Error on bumping manifest version for extension ${ext.name}: ${e}`);
-      return 1;
+      process.exit(1);
     }
   }
   /* eslint-enable no-restricted-syntax, no-await-in-loop */
 
   // #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext/blob/main/lib/bump-versions.ts
 
+  // Lint fix the changes
+  try {
+    await execCommand(`npm run format`);
+  } catch (e) {
+    console.error(`Error on formatting changes: ${e}`);
+    process.exit(1);
+  }
+
   // Commit the changes
   try {
     await execCommand(`git commit -a -m "Bump versions to ${newVersion}"`);
   } catch (e) {
     console.error(`Error on committing changes: ${e}`);
-    return 1;
+    process.exit(1);
   }
   // Publish the branch and push the changes
   try {
     await execCommand(`git push -u origin HEAD`);
   } catch (e) {
     console.error(`Error on publishing branch and pushing changes: ${e}`);
-    return 1;
+    process.exit(1);
   }
   console.log(
     `Bumped versions to ${newVersion} and pushed to branch ${branchName}. Please create a pull request to merge this branch into main.`,
   );
 
-  return 0;
+  process.exit(0);
 })();
 
 // #endregion


### PR DESCRIPTION
- Run `npm run format` in `bump-versions.ts` to avoid failing format check
- Create release tag with the release so GitHub knows which target we're aiming for
- Created `bump-versions.yml` so we can bump versions without releasing when appropriate
  - See new section [Common Release Processes](https://docs.google.com/document/d/1YDNTLUweF3USLUtxaoozMNMFBgzEzha91otWp4VlUuw/edit?tab=t.0#heading=h.u4xypon9fsyy) in the release doc for more info

Note: this was cherry-picked directly from https://github.com/paranext/platform-bible-sample-extensions/pull/44 with no merge conflicts.