### PR TITLE
PT-3107: Fixed error.message handling

### DIFF
--- a/lib/git.util.ts
+++ b/lib/git.util.ts
@@ -285,7 +285,11 @@ export async function formatExtensionFolder(extensionFolderPath: string) {
 
     console.log(`Updated module declaration and references in types file`);
   } catch (error) {
-    console.error(`Could not update types file: ${error.message}`);
+    if (error instanceof Error) {
+      console.error(`Could not update types file: ${error.message}`);
+    } else {
+      console.error(`An unknown error occurred while updating types file: ${error}`);
+    }
   }
 
   // Update README.md
@@ -332,7 +336,11 @@ export async function formatExtensionFolder(extensionFolderPath: string) {
     await fs.writeFile(readmePath, finalLines.join('\n'), 'utf8');
     console.log(`Updated README.md: modified title and summary sections only`);
   } catch (error) {
-    console.error(`Could not update README.md: ${error.message}`);
+    if (error instanceof Error) {
+      console.error(`Could not update README.md: ${error.message}`);
+    } else {
+      console.error(`An unknown error occurred while updating README.md: ${error}`);
+    }
   }
 
   // Update manifest.json
@@ -355,7 +363,11 @@ export async function formatExtensionFolder(extensionFolderPath: string) {
     await fs.writeFile(manifestPath, manifestContent, 'utf8');
     console.log(`Updated manifest.json with ${extensionName} information`);
   } catch (error) {
-    console.error(`Could not update manifest.json: ${error.message}`);
+    if (error instanceof Error) {
+      console.error(`Could not update manifest.json: ${error.message}`);
+    } else {
+      console.error(`An unknown error occurred while updating manifest.json: ${error}`);
+    }
   }
 
   // Update package.json
@@ -372,6 +384,10 @@ export async function formatExtensionFolder(extensionFolderPath: string) {
     await fs.writeFile(packagePath, packageContent, 'utf8');
     console.log(`Updated package.json with ${extensionName} information`);
   } catch (error) {
-    console.error(`Could not update package.json: ${error.message}`);
+    if (error instanceof Error) {
+      console.error(`Could not update package.json: ${error.message}`);
+    } else {
+      console.error(`An unknown error occurred while updating package.json: ${error}`);
+    }
   }
 }


### PR DESCRIPTION
Recently added formatting code was throwing errors when running bump versions:

```
extensions/lib/git.util.ts:410:53 - error TS18046: 'error' is of type 'unknown'.

410     console.error(`Could not update package.json: ${error.message}`);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/63)
<!-- Reviewable:end -->
