### PR TITLE
Auto-delete workspace package-lock.json files

### DIFF
--- a/lib/git.util.ts
+++ b/lib/git.util.ts
@@ -300,15 +300,9 @@ async function deleteUnusedPackageLockIfPresent(repoRootRelativePath: string): P
   }
 }
 
-/**
- * Format the repo root folder after a merge from the multi-extension template.
- *
- * Currently a no-op placeholder (the root `package-lock.json` is the monorepo lock file and is not
- * an unused workspace lock file). Exists as a named function to serve as a home for future
- * root-level formatting steps.
- */
+/** Format the repo root folder after a merge from the multi-extension template. */
 export async function formatExtensionsRoot() {
-  await deleteUnusedPackageLockIfPresent('package-lock.json');
+  // Currently a noop placeholder - add root-level formatting operations here in the future
 }
 
 /**

--- a/lib/git.util.ts
+++ b/lib/git.util.ts
@@ -3,8 +3,16 @@ import { promisify } from 'util';
 import path from 'path';
 import fs from 'fs/promises';
 import replaceInFile from 'replace-in-file';
+import { minimatch } from 'minimatch';
+
+// #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/git.util.ts
 
 const execAsync = promisify(exec);
+
+/** Absolute path to the repo root directory */
+const repoRoot = path.resolve(path.join(__dirname, '..'));
+
+// #endregion
 
 /** The name for the multi-extension template remote as used in the git scripts */
 export const MULTI_TEMPLATE_NAME = 'paranext-multi-extension-template';
@@ -18,6 +26,19 @@ export const SINGLE_TEMPLATE_NAME = 'paranext-extension-template';
 export const SINGLE_TEMPLATE_URL = 'https://github.com/paranext/paranext-extension-template';
 /** The branch to use in pulling changes from `SINGLE_TEMPLATE_REMOTE_NAME` in the git scripts */
 export const SINGLE_TEMPLATE_BRANCH = 'main';
+
+/** Cached npm workspaces list from root package.json, loaded once per process */
+let cachedWorkspaces: string[] | undefined;
+
+async function getWorkspaces(): Promise<string[]> {
+  if (cachedWorkspaces !== undefined) return cachedWorkspaces;
+  const content = await fs.readFile(path.join(repoRoot, 'package.json'), 'utf-8');
+  // JSON.parse returns unknown; we expect a package.json shape
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const packageJson = JSON.parse(content) as { workspaces?: string[] };
+  cachedWorkspaces = packageJson.workspaces ?? [];
+  return cachedWorkspaces;
+}
 
 // #region localization
 
@@ -86,7 +107,7 @@ export async function execCommand(
   if (!quiet) console.log(`\n>${execOptions.cwd ? ` cd ${execOptions.cwd};` : ''} ${command}`);
   try {
     const result = await execAsync(command, {
-      cwd: path.resolve(path.join(__dirname, '..')),
+      cwd: repoRoot,
       ...execOptions,
     });
     if (!quiet && result.stdout) console.log(result.stdout);
@@ -160,6 +181,78 @@ export async function fetchFromSingleTemplate() {
 }
 
 /**
+ * Returns true if the given repo-root-relative path is a `package-lock.json` file whose parent
+ * directory is an npm workspace under `src/`. Such files are unused (because the folder is a
+ * workspace) and are safe to delete automatically.
+ *
+ * @param repoRootRelativePath Repo-root-relative path, e.g. `src/hello-world/package-lock.json`
+ */
+export async function isUnusedWorkspacePackageLock(repoRootRelativePath: string): Promise<boolean> {
+  if (path.basename(repoRootRelativePath) !== 'package-lock.json') return false;
+  const parentDir = path.dirname(repoRootRelativePath);
+
+  // Must match a workspace pattern from the root package.json
+  const workspaces = await getWorkspaces();
+  return workspaces.some((pattern) => minimatch(parentDir, pattern));
+}
+
+/** Git status --porcelain v1 XY codes that indicate an unmerged (conflict) entry */
+const CONFLICT_XY_CODES = new Set(['DD', 'AU', 'UD', 'UA', 'DU', 'AA', 'UU']);
+
+/**
+ * After a `git subtree pull` or `git merge` fails, call this to auto-resolve any conflicts that are
+ * solely unused workspace `package-lock.json` files.
+ *
+ * Uses `git status --porcelain` (v1 format) — intentionally different from `checkForWorkingChanges`
+ * which uses `--porcelain=v2`. V1 is simpler for conflict-code parsing.
+ *
+ * For each conflicted `package-lock.json` that passes {@link isUnusedWorkspacePackageLock}, runs
+ * `git rm <path>` to delete and stage the file. Works for both:
+ *
+ * - `UU` (both modified): file is on disk with conflict markers
+ * - `DU` (deleted by us, modified by them): git leaves their version on disk during the conflict
+ *
+ * @returns `resolved` — number of lock files removed and staged. `remainingConflicts` —
+ *   repo-root-relative paths of all OTHER conflicted files.
+ */
+export async function resolvePackageLockConflicts(): Promise<{
+  resolved: number;
+  remainingConflicts: string[];
+}> {
+  const status = await execCommand('git status --porcelain', { quiet: true });
+
+  const lines = status.stdout.split('\n').filter((line) => line.length > 0);
+  const conflictLines = lines.filter((line) => CONFLICT_XY_CODES.has(line.slice(0, 2)));
+
+  const packageLockPaths: string[] = [];
+  const otherConflictPaths: string[] = [];
+
+  // Push order is non-deterministic across concurrent promises, but order doesn't matter here:
+  // all package-lock files get removed and remainingConflicts is only used for reporting.
+  await Promise.all(
+    conflictLines.map(async (line) => {
+      const filePath = line.slice(3); // skip "XY "
+      if (await isUnusedWorkspacePackageLock(filePath)) {
+        packageLockPaths.push(filePath);
+      } else {
+        otherConflictPaths.push(filePath);
+      }
+    }),
+  );
+
+  // Remove and stage each conflicted package-lock.json sequentially: each `git rm` must finish
+  // before the next to avoid interleaved git index updates.
+  // eslint-disable-next-line no-restricted-syntax
+  for (const filePath of packageLockPaths) {
+    // Intentional sequential await — see comment above the loop
+    // eslint-disable-next-line no-await-in-loop
+    await execCommand(`git rm "${filePath}"`);
+  }
+
+  return { resolved: packageLockPaths.length, remainingConflicts: otherConflictPaths };
+}
+
+/**
  * Converts kebab-case into camelCase. Assumes that the input is a valid kebab-case string
  *
  * Current implementation supports only UTF-16.
@@ -191,6 +284,34 @@ function toCamelCaseFromKebab(input: string): string {
 }
 
 /**
+ * Deletes a repo-root-relative path if it is an unused workspace `package-lock.json`. Silently
+ * skips if the file is absent.
+ *
+ * @param repoRootRelativePath Repo-root-relative path, e.g. `src/hello-world/package-lock.json`
+ */
+async function deleteUnusedPackageLockIfPresent(repoRootRelativePath: string): Promise<void> {
+  if (!(await isUnusedWorkspacePackageLock(repoRootRelativePath))) return;
+  try {
+    await fs.unlink(path.join(repoRoot, repoRootRelativePath));
+    console.log(`Deleted unused ${repoRootRelativePath}`);
+  } catch (error: unknown) {
+    // File not present — nothing to delete
+    if (!(error instanceof Error) || !('code' in error) || error.code !== 'ENOENT') throw error;
+  }
+}
+
+/**
+ * Format the repo root folder after a merge from the multi-extension template.
+ *
+ * Currently a no-op placeholder (the root `package-lock.json` is the monorepo lock file and is not
+ * an unused workspace lock file). Exists as a named function to serve as a home for future
+ * root-level formatting steps.
+ */
+export async function formatExtensionsRoot() {
+  await deleteUnusedPackageLockIfPresent('package-lock.json');
+}
+
+/**
  * Format an extension folder to make the extension template folder work as a subfolder of this repo
  *
  * This function may be called many times for one extension folder, so make sure all operations work
@@ -199,6 +320,9 @@ function toCamelCaseFromKebab(input: string): string {
  * @param extensionFolderPath Path to the extension to format relative to root
  */
 export async function formatExtensionFolder(extensionFolderPath: string) {
+  // Delete package-lock.json if present — it is unused because this folder is an npm workspace
+  await deleteUnusedPackageLockIfPresent(`${extensionFolderPath}/package-lock.json`);
+
   // Get the basename of the extension folder for use in replacements
   const extensionName = path.basename(extensionFolderPath);
   const extensionNameCamelCase = toCamelCaseFromKebab(extensionName);
@@ -214,8 +338,9 @@ export async function formatExtensionFolder(extensionFolderPath: string) {
       '**/.eslintcache',
       '**/dist/**/*',
       '**/release/**/*',
-      // With npm workspaces, child workspace package-lock.json files are not used. Let's not format
-      // them so they can stay the same as how they were in the template to avoid merge conflicts
+      // With npm workspaces, child workspace package-lock.json files are unused and are deleted
+      // proactively by formatExtensionFolder and formatExtensionsRoot. Skip them here in case they
+      // are present during a format pass before deletion runs.
       '**/package-lock.json',
     ],
     from: /([^/])\.\.\/paranext-core/g,

--- a/lib/update-from-templates.ts
+++ b/lib/update-from-templates.ts
@@ -8,8 +8,50 @@ import {
   execCommand,
   fetchFromSingleTemplate,
   formatExtensionFolder,
+  formatExtensionsRoot,
+  resolvePackageLockConflicts,
 } from './git.util';
 import { ExtensionInfo, getExtensions } from '../webpack/webpack.util';
+
+/**
+ * After a failed `git subtree pull` or `git merge`, attempts to auto-resolve any conflicts that are
+ * solely unused workspace `package-lock.json` files, then commits if fully resolved.
+ *
+ * @param context Human-readable label for error messages (template name or extension name)
+ * @param originalError The error thrown by the failed merge/pull
+ * @returns `'resolved'` if all conflicts were resolved and committed, `'failed'` otherwise (errors
+ *   already logged)
+ */
+async function handleConflicts(
+  context: string,
+  originalError: unknown,
+): Promise<'resolved' | 'failed'> {
+  const { resolved, remainingConflicts } = await resolvePackageLockConflicts();
+
+  if (resolved > 0 && remainingConflicts.length === 0) {
+    // MERGE_HEAD exists; git prepared a commit message. --no-edit reuses it.
+    await execCommand('git commit --no-edit');
+    console.log(
+      `Auto-resolved ${resolved} package-lock.json conflict(s) in ${context} by deleting unused lock files. Continuing.`,
+    );
+    return 'resolved';
+  }
+
+  if (resolved > 0) {
+    console.error(
+      `Auto-resolved package-lock.json conflicts in ${context}, but other merge conflicts remain:\n  ${remainingConflicts.join('\n  ')}`,
+    );
+  } else if (remainingConflicts.length > 0) {
+    // No package-lock.json conflicts resolved — other conflicts exist
+    console.error(
+      `Merge conflicts in ${context}:\n  ${remainingConflicts.join('\n  ')}\n\nOriginal error: ${originalError}`,
+    );
+  } else {
+    // No conflict lines at all — error was something other than a merge conflict
+    console.error(`Error in ${context}: ${originalError}`);
+  }
+  return 'failed';
+}
 
 (async () => {
   // Make sure there are not working changes as this will not work with working changes
@@ -29,8 +71,8 @@ import { ExtensionInfo, getExtensions } from '../webpack/webpack.util';
       `git merge ${MULTI_TEMPLATE_NAME}/${MULTI_TEMPLATE_BRANCH} --allow-unrelated-histories`,
     );
   } catch (e) {
-    console.error(`Error merging from ${MULTI_TEMPLATE_NAME}: ${e}`);
-    return 1;
+    if ((await handleConflicts('extensions root', e)) === 'failed') return 1;
+    // Fall through — do not return 1
   }
 
   // Fetch latest on SINGLE_TEMPLATE_REMOTE_NAME to make sure we're up to date
@@ -48,11 +90,12 @@ import { ExtensionInfo, getExtensions } from '../webpack/webpack.util';
   const extensionsBasedOnTemplate: ExtensionInfo[] = [];
 
   // Merge changes from SINGLE_TEMPLATE_REMOTE_NAME into each extension one at a time
-  // We intend to run these one at a time, so for/of works well here
+  // Subtree pulls must run one at a time: a merge conflict on one subtree leaves the repo in a
+  // conflicted state that blocks any further subtree work until it is resolved or aborted.
   // eslint-disable-next-line no-restricted-syntax
   for (const ext of extensions) {
     try {
-      // We intend to run these one at a time, so awaiting inside the loop works well here
+      // Intentional sequential await — one subtree pull must finish before the next begins
       // eslint-disable-next-line no-await-in-loop
       await execCommand(
         `git subtree pull --prefix ${ext.dirPathOSIndependent} ${SINGLE_TEMPLATE_NAME} ${SINGLE_TEMPLATE_BRANCH} --squash`,
@@ -75,20 +118,23 @@ import { ExtensionInfo, getExtensions } from '../webpack/webpack.util';
           `${ext.dirName} was never added as a subtree of ${SINGLE_TEMPLATE_NAME}. Feel free to ignore this if this folder is not supposed to be based on ${SINGLE_TEMPLATE_NAME}.\nIf this folder is supposed to be based on ${SINGLE_TEMPLATE_NAME}, move the folder elsewhere, run \`npm run create-extension -- ${ext.dirName}\`, drop the folder back in, and evaluate all working changes before committing.\n`,
         );
       else {
-        console.error(`Error pulling from ${SINGLE_TEMPLATE_NAME} to ${ext.dirName}: ${e}`);
         // You can only fix merge conflicts on one subtree at a time, so stop
         // if we hit an error like merge conflicts
-        return 1;
+        // Awaiting inside the loop is intentional — one subtree at a time
+        // eslint-disable-next-line no-await-in-loop
+        if ((await handleConflicts(ext.dirName, e)) === 'failed') return 1;
+        extensionsBasedOnTemplate.push(ext);
       }
     }
   }
 
   // Now that pulling all subtrees is finished and we can have working changes, format all the
   // SINGLE_TEMPLATE_REMOTE_NAME-based extension folders to make sure they work properly as subfolders of this
-  // repo
-  await Promise.all(
-    extensionsBasedOnTemplate.map((ext) => formatExtensionFolder(ext.dirPathOSIndependent)),
-  );
+  // repo. Also format the repo root (e.g. delete unused lock files) in the same pass.
+  await Promise.all([
+    formatExtensionsRoot(),
+    ...extensionsBasedOnTemplate.map((ext) => formatExtensionFolder(ext.dirPathOSIndependent)),
+  ]);
 
   // Check for working changes to see if formatting the extensions changed anything
   // Don't commit for them so they know what is going on

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "glob": "^10.5.0",
         "lucide-react": "^0.475.0",
+        "minimatch": "^9.0.9",
         "papi-dts": "file:../paranext-core/lib/papi-dts",
         "platform-bible-react": "file:../paranext-core/lib/platform-bible-react",
         "postcss": "^8.5.3",
@@ -846,6 +847,30 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
@@ -868,6 +893,30 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -2964,6 +3013,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/archiver-utils/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/archiver-utils/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -2989,6 +3049,19 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true
+    },
+    "node_modules/archiver-utils/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
       "version": "2.3.8",
@@ -3376,14 +3449,13 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/braces": {
@@ -3764,7 +3836,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concurrently": {
       "version": "9.1.2",
@@ -4796,6 +4869,17 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -4827,6 +4911,19 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -4896,6 +4993,30 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-no-null": {
@@ -5014,6 +5135,17 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
+    "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -5024,6 +5156,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
@@ -5086,6 +5231,17 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -5112,6 +5268,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/espree": {
@@ -5557,32 +5726,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/global-modules": {
       "version": "2.0.0",
@@ -7318,16 +7461,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -8326,16 +8472,6 @@
         "minimatch": "^5.1.0"
       }
     },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/readdir-glob/node_modules/minimatch": {
       "version": "5.1.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -8433,16 +8569,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/replace-in-file/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/replace-in-file/node_modules/glob": {
@@ -8576,6 +8702,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -8594,6 +8731,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/run-parallel": {
@@ -10925,6 +11075,17 @@
         "node": ">= 10"
       }
     },
+    "node_modules/zip-stream/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/zip-stream/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -10943,6 +11104,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/zip-stream/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     }
   },
@@ -11234,6 +11408,27 @@
         "js-yaml": "^4.1.0",
         "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "@eslint/js": {
@@ -11251,6 +11446,27 @@
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "@humanwhocodes/module-importer": {
@@ -12545,6 +12761,16 @@
         "readable-stream": "^2.0.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "glob": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -12564,6 +12790,15 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
           "dev": true
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         },
         "readable-stream": {
           "version": "2.3.8",
@@ -12832,13 +13067,12 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^1.0.0"
       }
     },
     "braces": {
@@ -13683,6 +13917,16 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -13697,6 +13941,15 @@
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^5.2.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -13838,6 +14091,16 @@
         "tsconfig-paths": "^3.15.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "debug": {
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -13863,6 +14126,15 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "semver": {
@@ -13919,6 +14191,25 @@
           "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
           "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
           "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
         }
       }
     },
@@ -13979,6 +14270,16 @@
         "string.prototype.repeat": "^1.0.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "doctrine": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -13986,6 +14287,15 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         },
         "resolve": {
@@ -14341,26 +14651,6 @@
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-          "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "9.0.9",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-          "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.2"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -15511,12 +15801,12 @@
       }
     },
     "minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       }
     },
     "minimist": {
@@ -16266,15 +16556,6 @@
         "minimatch": "^5.1.0"
       },
       "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-          "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "minimatch": {
           "version": "5.1.9",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
@@ -16342,15 +16623,6 @@
         "yargs": "^17.7.2"
       },
       "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-          "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
-          "dev": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
         "glob": {
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
@@ -16442,6 +16714,16 @@
         "glob": "^7.1.3"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "glob": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -16454,6 +16736,15 @@
             "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -18021,6 +18312,16 @@
             "readable-stream": "^3.6.0"
           }
         },
+        "brace-expansion": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+          "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
         "glob": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -18033,6 +18334,15 @@
             "minimatch": "^3.1.1",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+          "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react": "^7.37.4",
     "eslint-plugin-react-hooks": "^4.6.2",
     "glob": "^10.5.0",
+    "minimatch": "^9.0.9",
     "lucide-react": "^0.475.0",
     "papi-dts": "file:../paranext-core/lib/papi-dts",
     "platform-bible-react": "file:../paranext-core/lib/platform-bible-react",


### PR DESCRIPTION
dependabot kept spamming us with silly changes to the workspace package-lock.json files that are unused. But we wanted to keep these files synced with the template so we didn't have merge conflicts with them when updating from templates. Now, instead of having the useless extension package-lock.json files in our repo, this PR removes them and automatically resolves merge conflicts with those files by just deleting the file again. Hopefully we don't have to think about those extension package-lock.json files anymore.

See https://github.com/paranext/paranext-core/pull/2163 for more info

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/86)
<!-- Reviewable:end -->
