### PR TITLE
Add Dark Mode Selector

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,9 @@ import tailwindCssAnimate from 'tailwindcss-animate';
 
 const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx}', '!./**/node_modules/**/*'],
+  // Use selector-based dark mode so `dark:` variants activate when the `.dark` class is on <html>,
+  // matching how Paranext-Core toggles the theme at runtime.
+  darkMode: 'selector',
   // Prefix on all tailwind classes so they don't clash with built-in classes
   // short for tailwind - we hope to have the same prefix as users of this library so the cn
   // function that uses tailwind-merge can properly overwrite related tailwind classes


### PR DESCRIPTION
Add dark mode selector to match paranext-core change made as part of https://github.com/paranext/paranext-core/pull/2154 for https://paratextstudio.atlassian.net/browse/PT-3897

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/89)
<!-- Reviewable:end -->
