### PR TITLE
Keep Sass output expanded so production builds can use Tailwind

### DIFF
--- a/webpack/webpack.config.base.ts
+++ b/webpack/webpack.config.base.ts
@@ -111,7 +111,18 @@ const configBase: webpack.Configuration = {
           // Processes style transformations in PostCSS - after scss so PostCSS runs on just css
           'postcss-loader',
           // Compiles Sass to CSS
-          'sass-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                // Stay expanded even in production. sass-loader would otherwise compress, which
+                // strips the space in `@import 'tailwindcss' prefix(tw);` — @tailwindcss/postcss
+                // then never registers the `tw` variant and every `@apply tw:*` fails the build.
+                // Nothing is lost: Tailwind's PostCSS plugin optimizes production output itself.
+                style: 'expanded',
+              },
+            },
+          },
         ],
       },
       /**


### PR DESCRIPTION
`npm run build:production` fails for any extension whose styles pull in `tailwind.css`:

```
ERROR in ./src/my.web-view.scss?inline
Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):

SyntaxError

(1:1) from "tailwindcss" plugin: .../src/my.web-view.scss Cannot apply utility class `tw:relative` because the `tw` variant does not exist.
```

sass-loader forces `style: 'compressed'` whenever webpack runs in production mode. Compressed output drops the space in `@import 'tailwindcss' prefix(tw);`, so `@tailwindcss/postcss` never registers the `tw` variant and every `@apply tw:*` fails. Dev builds pass because Sass output is expanded there, so this only surfaces in `npm run build:production`.

Root cause isolated to Dart Sass + `@tailwindcss/postcss`, no webpack involved:

| sass `style` | Sass emits | `@tailwindcss/postcss` |
| --- | --- | --- |
| `expanded` | `@import "tailwindcss" prefix(tw);` | OK |
| `compressed` | `@import"tailwindcss"prefix(tw);` | `tw` variant does not exist |

Compressing here was destructive and, for Tailwind-processed styles, redundant: `@tailwindcss/postcss` runs after Sass and minifies its own output when `NODE_ENV` is production.

### Trade-off: stylesheets with no Tailwind in them

The rule matches `.css` too, so this changes every stylesheet, not just the Tailwind entry. Measured with `@tailwindcss/postcss` in production:

| stylesheet | sass compressed | sass expanded |
| --- | --- | --- |
| Tailwind-consuming (interlinearizer's WebView `.scss`) | build fails | 86,741 B, minified by the Tailwind plugin (101,758 B in dev) |
| plain CSS, no Tailwind (a 138 B stylesheet) | 99 B | 137 B — the plugin returns it untouched |

So a stylesheet that uses Tailwind is still minified; one that does not now ships expanded, costing tens of bytes on a typical WebView stylesheet. Anyone who wants those minified should add a CSS minifier to `postcss.config`, which is where CSS optimization belongs — Sass compression only ever did it as a side effect, and did it by corrupting Tailwind's directives.

**Considered and rejected:** giving `tailwind.css` its own webpack rule without sass-loader. That only covers importing `./tailwind.css?inline` from code. Sass resolves `@use`/`@import` of local files itself, so the pattern this README recommends — `@use './path/to/src/tailwind';` in a WebView stylesheet — never reaches webpack as a separate module and would keep failing.

## Test plan

- Verified in an extension built from these templates: with everything else left alone, `npm run build:production` goes from the error above to emitting the compiled utilities (`.tw\:flex{display:flex}`) in the bundle, with no meaningful size change.
- Neither template builds a `tailwind.css` of its own (this repo has none at all — extensions arrive as subtrees), so their own production builds cannot catch this. A smoke build of a scaffolded extension would be a reasonable follow-up.

Sibling PR, identical patch, so the `#region shared with` block stays in sync: paranext/paranext-extension-template#161

---

🤖 Generated with [Claude Code](https://claude.com/claude-code), model Claude Opus 5 (1M context) — `claude-opus-5[1m]`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-multi-extension-template/97)
<!-- Reviewable:end -->
